### PR TITLE
add ignore_case option to regex_joins 

### DIFF
--- a/R/regex_join.R
+++ b/R/regex_join.R
@@ -8,6 +8,7 @@
 #' @param y A tbl
 #' @param by Columns by which to join the two tables
 #' @param mode One of "inner", "left", "right", "full" "semi", or "anti"
+#' @param ignore_case @param ignore_case Whether to be case insensitive (default no)
 #'
 #' @seealso \code{\link{str_detect}}
 #'
@@ -33,10 +34,7 @@
 #' @export
 regex_join <- function(x, y, by = NULL, mode = "inner", ignore_case = FALSE) {
   match_fun <- function(v1, v2) {
-    if (ignore_case) {
-      v2 <- stringr::fixed(v2, ignore_case = T)  
-    }
-    stringr::str_detect(v1, v2)
+    stringr::str_detect(v1, stringr::fixed(v2, ignore_case = ignore_case))
   }
 
   fuzzy_join(x, y, by = by, match_fun = match_fun, mode = mode)

--- a/R/regex_join.R
+++ b/R/regex_join.R
@@ -45,41 +45,41 @@ regex_join <- function(x, y, by = NULL, mode = "inner", ignore_case = FALSE) {
 
 #' @rdname regex_join
 #' @export
-regex_inner_join <- function(x, y, by = NULL) {
+regex_inner_join <- function(x, y, by = NULL, ignore_case = FALSE) {
   regex_join(x, y, by, mode = "inner")
 }
 
 
 #' @rdname regex_join
 #' @export
-regex_left_join <- function(x, y, by = NULL) {
+regex_left_join <- function(x, y, by = NULL, ignore_case = FALSE) {
   regex_join(x, y, by, mode = "left")
 }
 
 
 #' @rdname regex_join
 #' @export
-regex_right_join <- function(x, y, by = NULL) {
+regex_right_join <- function(x, y, by = NULL, ignore_case = FALSE) {
   regex_join(x, y, by, mode = "right")
 }
 
 
 #' @rdname regex_join
 #' @export
-regex_full_join <- function(x, y, by = NULL) {
+regex_full_join <- function(x, y, by = NULL, ignore_case = FALSE) {
   regex_join(x, y, by, mode = "full")
 }
 
 
 #' @rdname regex_join
 #' @export
-regex_semi_join <- function(x, y, by = NULL) {
+regex_semi_join <- function(x, y, by = NULL, ignore_case = FALSE) {
   regex_join(x, y, by, mode = "semi")
 }
 
 
 #' @rdname regex_join
 #' @export
-regex_anti_join <- function(x, y, by = NULL) {
+regex_anti_join <- function(x, y, by = NULL, ignore_case = FALSE) {
   regex_join(x, y, by, mode = "anti")
 }

--- a/R/regex_join.R
+++ b/R/regex_join.R
@@ -31,8 +31,11 @@
 #'  regex_inner_join(d, by = c(cut = "regex_name"))
 #'
 #' @export
-regex_join <- function(x, y, by = NULL, mode = "inner") {
+regex_join <- function(x, y, by = NULL, mode = "inner", ignore_case = FALSE) {
   match_fun <- function(v1, v2) {
+    if (ignore_case) {
+      v2 <- stringr::fixed(v2, ignore_case = T)  
+    }
     stringr::str_detect(v1, v2)
   }
 

--- a/R/regex_join.R
+++ b/R/regex_join.R
@@ -8,7 +8,7 @@
 #' @param y A tbl
 #' @param by Columns by which to join the two tables
 #' @param mode One of "inner", "left", "right", "full" "semi", or "anti"
-#' @param ignore_case @param ignore_case Whether to be case insensitive (default no)
+#' @param ignore_case Whether to be case insensitive (default no)
 #'
 #' @seealso \code{\link{str_detect}}
 #'

--- a/R/regex_join.R
+++ b/R/regex_join.R
@@ -44,40 +44,40 @@ regex_join <- function(x, y, by = NULL, mode = "inner", ignore_case = FALSE) {
 #' @rdname regex_join
 #' @export
 regex_inner_join <- function(x, y, by = NULL, ignore_case = FALSE) {
-  regex_join(x, y, by, mode = "inner")
+  regex_join(x, y, by, mode = "inner", ignore_case = ignore_case)
 }
 
 
 #' @rdname regex_join
 #' @export
 regex_left_join <- function(x, y, by = NULL, ignore_case = FALSE) {
-  regex_join(x, y, by, mode = "left")
+  regex_join(x, y, by, mode = "left", ignore_case = ignore_case)
 }
 
 
 #' @rdname regex_join
 #' @export
 regex_right_join <- function(x, y, by = NULL, ignore_case = FALSE) {
-  regex_join(x, y, by, mode = "right")
+  regex_join(x, y, by, mode = "right", ignore_case = ignore_case)
 }
 
 
 #' @rdname regex_join
 #' @export
 regex_full_join <- function(x, y, by = NULL, ignore_case = FALSE) {
-  regex_join(x, y, by, mode = "full")
+  regex_join(x, y, by, mode = "full", ignore_case = ignore_case)
 }
 
 
 #' @rdname regex_join
 #' @export
 regex_semi_join <- function(x, y, by = NULL, ignore_case = FALSE) {
-  regex_join(x, y, by, mode = "semi")
+  regex_join(x, y, by, mode = "semi", ignore_case = ignore_case)
 }
 
 
 #' @rdname regex_join
 #' @export
 regex_anti_join <- function(x, y, by = NULL, ignore_case = FALSE) {
-  regex_join(x, y, by, mode = "anti")
+  regex_join(x, y, by, mode = "anti", ignore_case = ignore_case)
 }

--- a/R/regex_join.R
+++ b/R/regex_join.R
@@ -34,7 +34,7 @@
 #' @export
 regex_join <- function(x, y, by = NULL, mode = "inner", ignore_case = FALSE) {
   match_fun <- function(v1, v2) {
-    stringr::str_detect(v1, stringr::fixed(v2, ignore_case = ignore_case))
+    stringr::str_detect(v1, stringr::regex(v2, ignore_case = ignore_case))
   }
 
   fuzzy_join(x, y, by = by, match_fun = match_fun, mode = mode)


### PR DESCRIPTION
Using `stringr::fixed` it's incredibly easy to add the `ignore_case` option to all the `regex_join` functions. Not sure though about consistency with the `stringdist_join` api where `ignore_case` argument is earlier, and is by default yes. (OTOH, to be backwards compatible, better to leave default no for `regex_join`)