### PR TITLE
changing stringdist-methods to stringdist-metrics

### DIFF
--- a/R/stringdist_join.R
+++ b/R/stringdist_join.R
@@ -11,7 +11,7 @@
 #' @param max_dist Maximum distance to use for joining
 #' @param ignore_case Whether to be case insensitive (default yes)
 #' @param method Method for computing string distance, see
-#' \code{stringdist-methods} in the stringdist package.
+#' \code{stringdist-metrics} in the stringdist package.
 #' @param distance_col If given, will add a column with this
 #' name containing the difference between the two
 #' @param mode One of "inner", "left", "right", "full" "semi", or "anti"

--- a/docs/reference/stringdist_join.html
+++ b/docs/reference/stringdist_join.html
@@ -138,7 +138,7 @@ small personal changes.</p>
     <tr>
       <th>method</th>
       <td><p>Method for computing string distance, see
-<code>stringdist-methods</code> in the stringdist package.</p></td>
+<code>stringdist-metrics</code> in the stringdist package.</p></td>
     </tr>
     <tr>
       <th>mode</th>


### PR DESCRIPTION
This is a very small change (/typo fix?) - I don't think there is a `stringdist-methods` documentation page in the stringdist package, so replacing the 2 instances of that (one in .R, one in .html) with `stringdist-metrics`.  

Thanks! 